### PR TITLE
fix(release): write composer.json to host workspace, add macOS PIE binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
   Source:
     runs-on: ubuntu-24.04
     env:
-      PSKEL_BUILD_TARGET: base
+      PSKEL_BUILD_TARGET: builder
     outputs:
       extension-name: ${{ steps.metadata.outputs.extension-name }}
       version: ${{ steps.metadata.outputs.version }}
@@ -102,6 +102,37 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${GITHUB_REF_NAME}" dist/*.zip --clobber
+  macOS:
+    needs: Source
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        runs-on: ['macos-15', 'macos-15-intel']
+        version: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        ts: ['ts', 'nts']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Download initialized extension
+        if: needs.Source.outputs.needs-init == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: initialized-ext-release
+          path: ext/
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ matrix.version }}
+          extensions: none
+        env:
+          phpts: ${{ matrix.ts }}
+      - name: Build and upload PIE pre-packaged binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p "dist"
+          ./pskel.sh package "${GITHUB_REF_NAME}" "dist" "${{ needs.Source.outputs.extension-name }}"
+          gh release upload "${GITHUB_REF_NAME}" dist/*.zip --clobber
   Windows:
     needs: Source
     runs-on: windows-2025

--- a/pskel.sh
+++ b/pskel.sh
@@ -68,6 +68,8 @@ get_workspace_dir() {
     echo "${PSKEL_WORKSPACE_DIR}"
   elif PWD_WORKSPACE_DIR="$(find_workspace_dir_from_pwd 2>/dev/null)" && test -n "${PWD_WORKSPACE_DIR}"; then
     echo "${PWD_WORKSPACE_DIR}"
+  elif test -f "/workspace/pskel.sh" && test -f "/workspace/.pskel/LICENSE.template"; then
+    echo "/workspace"
   else
     PSKEL_ROOT_DIR="$(get_pskel_root_dir)" || return 1
     if test -d "${PSKEL_ROOT_DIR}"; then
@@ -694,13 +696,13 @@ EOF
 
   cd "${PSKEL_EXT_DIR}"
     phpize
-    if test "$(php -r "echo PHP_VERSION_ID;")" -lt "80400"; then
+    if test "$(uname -s)" != "Darwin" && test "$(php -r "echo PHP_VERSION_ID;")" -lt "80400"; then
       patch "./build/ltmain.sh" "./../patches/ltmain.sh.patch"
       echo "[Pskel] ltmain.sh patched" >&2
     fi
     ./configure --with-php-config="$(command -v "php-config")" ${EXT_CONFIGURE_OPTS}
     make clean
-    make -j"$(nproc)"
+    make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
   cd -
 
   if ! php -n -d "extension=${PSKEL_EXT_DIR}/modules/${PKG_EXT_NAME}.so" -m | grep -q "^${PKG_EXT_NAME}\$"; then


### PR DESCRIPTION
## Summary

**Fixes the failed Release run** (`Verify project is initialized` → composer.json not found): the fallback `pskel init skeleton` wrote `composer.json` to `/opt/pskel` inside the container because `get_workspace_dir` never considered the compose-mounted `/workspace` when the working directory is outside it (`docker compose run` defaults to `/`). An explicit `/workspace` fallback now places the generated `composer.json` in the host checkout.

**Completes the prebuilt binary matrix with macOS** (Linux was added in #77, Windows already existed):
- New `macOS` release job: `macos-15` (arm64) + `macos-15-intel` (x86_64) × PHP 8.1–8.5 × ts/nts = 20 assets, built natively with `pskel package` (`darwin`/`bsdlibc` PIE naming)
- `cmd_package`: `sysctl -n hw.ncpu` fallback where `nproc` is unavailable; the Linux-only ltmain.sh patch is skipped on Darwin (mirrors the proven ci_macos build steps)
- `Source` job now uses the lightweight `builder` target instead of the full base image (no Valgrind/LLVM needed for skeleton init)

## Test plan

- [x] Container replication of the Source job (`docker compose run ... pskel init skeleton`, builder target): `composer.json` and initialized `ext/` land in the host checkout, extension-name resolves to `skeleton`
- [x] Native macOS (arm64, Homebrew PHP 8.5 NTS): `pskel package` produced `php_skeleton-v9.9.9-mac_php8.5-arm64-darwin-bsdlibc.zip` containing `skeleton.so`, load smoke test passed
- [ ] Re-tag after merge to verify the full release pipeline (Linux 40 + macOS 20 + Windows 20 assets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)