### PR TITLE
fix(release): remove uninitialized marker restored by checkout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,6 +91,9 @@ jobs:
         with:
           name: initialized-ext-release
           path: ext/
+      - name: Remove uninitialized marker restored by checkout
+        if: needs.Source.outputs.needs-init == 'true'
+        run: rm -f "ext/.gitkeep"
       - name: Build PIE pre-packaged binary
         run: |
           docker compose build \
@@ -119,6 +122,9 @@ jobs:
         with:
           name: initialized-ext-release
           path: ext/
+      - name: Remove uninitialized marker restored by checkout
+        if: needs.Source.outputs.needs-init == 'true'
+        run: rm -f "ext/.gitkeep"
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:


### PR DESCRIPTION
## Summary

Fixes the macOS release job failure:

```
[Pskel] Uninitialized project detected, initializing default skeleton.
Could not open input file: /usr/src/php/ext/ext_skel.php
```

The `initialized-ext-release` artifact contains no `ext/.gitkeep` (`pskel init` removes it), but each binary job's fresh checkout restores the marker from git, and `actions/download-artifact` merges into `ext/` without deleting existing files. `pskel package` then saw the `pskel_uninitialized` marker next to a fully initialized skeleton and attempted a fallback init — impossible on macOS runners where `/usr/src/php` doesn't exist (the Linux jobs only survived by wastefully re-initializing inside the container).

Fix: drop the stale marker right after the artifact download in the `Linux` and `macOS` jobs (`Windows` doesn't invoke pskel).

## Test plan

- [x] Reproduced locally on macOS: re-adding the marker to an initialized ext produces the exact CI failure; removing it lets `pskel package` produce `php_skeleton-…-darwin-bsdlibc.zip`
- [ ] Re-tag after merge to verify the full release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)