### PR TITLE
refactor(release): distribute extension sources via a single artifact

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,6 @@ jobs:
     outputs:
       extension-name: ${{ steps.metadata.outputs.extension-name }}
       version: ${{ steps.metadata.outputs.version }}
-      needs-init: ${{ steps.check.outputs.needs-init }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -29,11 +28,10 @@ jobs:
         if: steps.check.outputs.needs-init == 'true'
         run: |
           docker compose run -v "$(pwd)/ext:/ext" --rm shell pskel init skeleton
-      - name: Upload initialized extension
-        if: steps.check.outputs.needs-init == 'true'
+      - name: Upload prepared extension
         uses: actions/upload-artifact@v7
         with:
-          name: initialized-ext-release
+          name: release-ext
           path: ext/
           retention-days: 1
       - name: Verify project is initialized
@@ -85,15 +83,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-      - name: Download initialized extension
-        if: needs.Source.outputs.needs-init == 'true'
+      - name: Remove checked-out extension sources
+        run: rm -rf "ext"
+      - name: Download prepared extension
         uses: actions/download-artifact@v8
         with:
-          name: initialized-ext-release
+          name: release-ext
           path: ext/
-      - name: Remove uninitialized marker restored by checkout
-        if: needs.Source.outputs.needs-init == 'true'
-        run: rm -f "ext/.gitkeep"
       - name: Build PIE pre-packaged binary
         run: |
           docker compose build \
@@ -116,15 +112,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-      - name: Download initialized extension
-        if: needs.Source.outputs.needs-init == 'true'
+      - name: Remove checked-out extension sources
+        run: rm -rf "ext"
+      - name: Download prepared extension
         uses: actions/download-artifact@v8
         with:
-          name: initialized-ext-release
+          name: release-ext
           path: ext/
-      - name: Remove uninitialized marker restored by checkout
-        if: needs.Source.outputs.needs-init == 'true'
-        run: rm -f "ext/.gitkeep"
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
@@ -150,11 +144,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-      - name: Download initialized extension
-        if: needs.Source.outputs.needs-init == 'true'
+      - name: Remove checked-out extension sources
+        shell: pwsh
+        run: Remove-Item -LiteralPath .\ext -Recurse -Force
+      - name: Download prepared extension
         uses: actions/download-artifact@v8
         with:
-          name: initialized-ext-release
+          name: release-ext
           path: ext/
       - name: Stage extension source for Windows builder
         shell: pwsh


### PR DESCRIPTION
## Summary

Implements the cleaner initialization flow: the `Source` job (Linux container) is the single authority for extension sources — it checks initialization, runs the `pskel init skeleton` fallback when the template repo itself is tagged, and **always** uploads the resulting `ext/` as the `release-ext` artifact. All platform jobs (`Linux`, `macOS`, `Windows`) delete the checked-out `ext/` and download the artifact unconditionally.

Benefits:
- Every platform builds from byte-identical extension sources
- The `needs-init` conditionals in the platform jobs and the stale `.gitkeep` marker workaround (#79) disappear structurally — a fresh checkout can no longer reintroduce the uninitialized marker next to initialized sources
- Downstream projects behave identically (their committed `ext/` just passes through the artifact)

## Test plan

- [x] YAML validation; no remaining `needs-init` references outside the Source job
- [ ] Re-tag to verify the full release pipeline (Linux 40 + macOS 20 + Windows 20 assets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)