### PR TITLE
fix(coverage): collect the shard from the workspace ext directory

### DIFF
--- a/.github/workflows/ci_coverage.yaml
+++ b/.github/workflows/ci_coverage.yaml
@@ -90,9 +90,8 @@ jobs:
             --build-arg TAG="${{ matrix.versions }}-${{ matrix.ts }}-trixie" \
             --build-arg SKIP_VALGRIND=1 \
             shell
-          touch "lcov.info"
-          docker compose run -v "$(pwd)/lcov.info:/ext/lcov.info" --rm shell pskel coverage
-          mv "lcov.info" "${{ matrix.platform }}_${{ matrix.versions }}_${{ matrix.ts }}_lcov.info"
+          docker compose run --rm shell pskel coverage
+          mv "ext/lcov.info" "${{ matrix.platform }}_${{ matrix.versions }}_${{ matrix.ts }}_lcov.info"
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

Fixes the `Coverage / deploy-pages` failure on main (`Error: missing FNL: records in .../ubuntu-24.04-arm_8.5_cli_lcov.info`).

Root cause: since #78 taught `get_workspace_dir` to detect the compose-mounted `/workspace`, `pskel coverage` captures into `/workspace/ext/lcov.info` — i.e. the host checkout's `ext/lcov.info` — instead of the image's `/ext`. The coverage job still bind-mounted an empty host file over `/ext/lcov.info` and shipped that untouched empty file as the shard; `pskel coverage-report` then correctly rejected it at merge time.

Fix: drop the `touch` + single-file bind mount and take the shard directly from `ext/lcov.info` (delivered via the standard workspace mount). Verified locally with the CI-shaped invocation: the host file contains full lcov 2.x records (FNL/FNA/FNF/FNH/DA); the new `SF:/workspace/ext/...` source paths resolve in the deploy-pages container through the same workspace mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)