### PR TITLE
fix(coverage): copy the shard instead of moving a root-owned file

### DIFF
--- a/.github/workflows/ci_coverage.yaml
+++ b/.github/workflows/ci_coverage.yaml
@@ -86,12 +86,13 @@ jobs:
           path: ext/
       - name: Build container and run coverage
         run: |
+          rm -f "ext/.gitkeep"
           docker compose build \
             --build-arg TAG="${{ matrix.versions }}-${{ matrix.ts }}-trixie" \
             --build-arg SKIP_VALGRIND=1 \
             shell
           docker compose run --rm shell pskel coverage
-          mv "ext/lcov.info" "${{ matrix.platform }}_${{ matrix.versions }}_${{ matrix.ts }}_lcov.info"
+          cp "ext/lcov.info" "${{ matrix.platform }}_${{ matrix.versions }}_${{ matrix.ts }}_lcov.info"
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

Fixes the `Coverage / coverage` failure on main (`mv: cannot move 'ext/lcov.info' ...: Permission denied`). The capture succeeded, but the file written by the container (root) could not be moved by the runner user. `cp` only needs read access and produces a runner-owned shard, so the collection step uses it instead. The checkout-restored `ext/.gitkeep` marker is also removed before the run so the container does not needlessly re-initialize the downloaded extension sources.

The other failure in the same run (`Linux_Emulated s390x 8.4 zts alpine` — Setup QEMU step) was another transient Docker Hub connection timeout, unrelated to any change; the post-merge run will retry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)